### PR TITLE
Better type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,26 @@ The assembly instructions always take arguments of: constant integers known at c
 
 The lower intermediate representation is the type-checked layer of the compiler; all of the intermediate representations constructed on top of this layer are expressed in terms of LIR code before type-checking. LIR is high level enough to be *decently* human readable and usable. It's a bit more terse than C, but not by much. The type system is very expressive, and allows for unions, enums, procedures (as values), structures, arrays, and anonymous recursive types.
 
+Here's an example of an anynomous recursive type implementing a linked list which can be typed-checked and compiled to the virtual machine:
+
+```rs
+const putint = proc(i: Int) -> None = std {
+    put-int [SP]
+    pop
+} in
+
+type List = let B = let T = Int in (T, &B) in B in
+
+let x = (3, Null),
+    y = (2, &x),
+    z: (let A = (Int, &A) in A) = (1, &y),
+    w: List = (0, &z)
+    in putint(w.1->1->1->0)
+```
+
 [***Click here to use the interactive compiler online!***](https://adam-mcdaniel.net/sage)
+
+#### Examples
 
 - [128, 192, and 256 bit AES encryption and decryption](examples/lir/AES.lir.sg)
 - [Quicksort](examples/lir/quicksort.lir.sg)

--- a/src/lir/types.rs
+++ b/src/lir/types.rs
@@ -567,7 +567,10 @@ impl Type {
             Type::Struct(members) => {
                 let mut offset = 0;
                 for (k, t) in members.clone() {
+                    // If this element is the requested member
                     if &ConstExpr::Symbol(k) == member {
+                        // Return the member's type and the offset in memory
+                        // from the value's address
                         return Ok((t.simplify(env)?, offset));
                     }
 
@@ -579,8 +582,12 @@ impl Type {
             Type::Tuple(items) => {
                 let mut offset = 0;
                 for (i, t) in items.iter().enumerate() {
+                    // If this element is the requested member
                     if &ConstExpr::Int(i as i32) == member {
+                        // Simplify the type under the environment
                         let result = t.clone().simplify(env)?;
+                        // Return the member's type and its offset in memory
+                        // from the value's address.
                         return Ok((result, offset));
                     }
 
@@ -595,8 +602,11 @@ impl Type {
             },
 
             Type::Let(name, t, ret) => {
+                // Create a new scope and define the new type within it
                 let mut new_env = env.clone();
                 new_env.define_type(name, *t.clone());
+                // Find the member offset of the returned type under the new scope
+                // 
                 // NOTE:
                 // We simplfy the type before AND after getting the member offset because
                 // we want to make sure that recursive types don't leave undefined symbols


### PR DESCRIPTION
Added a simple fix to make type-checking better for the `Let` type.

Previously, the following program would return a nonsense error `Symbol "B" not defined`:

```rs
const putint = proc(i: Int) -> None = std {
    put-int [SP]
    pop
} in

type List = let B = let T = Int in (T, &B) in B in

let x = (3, Null),
    y = (2, &x),
    z: List = (1, &y),
    in putint(z.1->1->0)
```

This should not fail, but it's due to a simple bug caused by not simplifying the `Let` type before returning in `get_member_offset`, causing undefined symbols (which are defined in the `Let` scope) to be left in the returned type.

Now, the following program type-checks as expected:

```rs
const putint = proc(i: Int) -> None = std {
    put-int [SP]
    pop
} in

type List = let B = let T = Int in (T, &B) in B in

let x = (3, Null),
    y = (2, &x),
    z: (let A = (Int, &A) in A) = (1, &y),
    w: List = (0, &z)
    in putint(w.1->1->1->0)
```