### PR TITLE
Optimized generated assembly for index operations

### DIFF
--- a/src/frontend/parse.rs
+++ b/src/frontend/parse.rs
@@ -13,7 +13,6 @@ struct FrontendParser;
 
 #[derive(Clone, Debug)]
 pub enum Statement {
-    Match(Expr, Vec<(Pattern, Self)>),
     Let(Vec<(String, Option<Type>, Expr)>),
     Assign(Expr, Option<Box<dyn AssignOp + 'static>>, Expr),
     If(Expr, Box<Self>, Option<Box<Self>>),
@@ -36,12 +35,6 @@ impl Statement {
         // }, rest_expr])
 
         let stmt = match (self, rest.clone()) {
-            (Self::Match(e, arms), _) => Expr::Match(
-                Box::new(e),
-                arms.into_iter()
-                    .map(|(a, b)| (a, b.to_expr(None)))
-                    .collect(),
-            ),
             (Self::Assign(lhs, op, rhs), _) => {
                 match op {
                     Some(op) => lhs.refer().assign(op, rhs),

--- a/src/lir/expr/const_expr.rs
+++ b/src/lir/expr/const_expr.rs
@@ -15,7 +15,7 @@ use crate::lir::{
 };
 
 use core::fmt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// A compiletime expression.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lir/expr/procedure/poly.rs
+++ b/src/lir/expr/procedure/poly.rs
@@ -75,7 +75,7 @@ impl PolyProcedure {
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let bind_type_args = |mut ty: Type| -> Result<Type, Error> {
+        let bind_type_args = |mut _ty: Type| -> Result<Type, Error> {
             // for (name, arg) in self.ty_params.iter().zip(ty_args.iter()) {
             //     // ty = Type::let_bind(name, if arg == &Type::Symbol(name.clone()) {
             //     //     Type::Unit(name.clone(), Box::new(Type::Any))

--- a/src/lir/expr/procedure/poly.rs
+++ b/src/lir/expr/procedure/poly.rs
@@ -75,7 +75,7 @@ impl PolyProcedure {
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let bind_type_args = |mut _ty: Type| -> Result<Type, Error> {
+        let bind_type_args = |ty: Type| -> Result<Type, Error> {
             // for (name, arg) in self.ty_params.iter().zip(ty_args.iter()) {
             //     // ty = Type::let_bind(name, if arg == &Type::Symbol(name.clone()) {
             //     //     Type::Unit(name.clone(), Box::new(Type::Any))

--- a/src/lir/types/size.rs
+++ b/src/lir/types/size.rs
@@ -150,7 +150,7 @@ impl GetSize for Type {
             }
 
             // Get the size of an `Apply` type.
-            Self::Apply(poly, ty_args) => {
+            Self::Apply(poly, _ty_args) => {
                 if let Ok(size) = poly.get_size_checked(env, i) {
                     return Ok(size);
                 }
@@ -158,7 +158,7 @@ impl GetSize for Type {
                 let result = self.clone().simplify_until_matches(
                     env,
                     Type::Poly(vec![], Box::new(Type::Any)),
-                    |t, env| Ok(t.is_simple()),
+                    |t, _env| Ok(t.is_simple()),
                 )?;
 
                 result.get_size_checked(env, i)?

--- a/src/targets/x86.rs
+++ b/src/targets/x86.rs
@@ -195,7 +195,7 @@ impl Architecture for X86 {
         })
     }
 
-    fn end(&mut self, matching: &CoreOp, fun: Option<usize>) -> String {
+    fn end(&mut self, matching: &CoreOp, _fun: Option<usize>) -> String {
         match matching {
             CoreOp::Function => {
                 let label = self.branch_match.pop().unwrap();
@@ -213,7 +213,7 @@ impl Architecture for X86 {
         }
     }
 
-    fn declare_proc(&mut self, label_id: usize) -> String {
+    fn declare_proc(&mut self, _label_id: usize) -> String {
         let result = format!("movq $fun{fun_count}, funs+{}(%rip)\n{indent}jmp fun_end{fun_count}\nfun{fun_count}:\n{indent}pushq   %rbp\n{indent}movq %rsp, %rbp\n", self.fun_count * 8, fun_count = self.fun_count, indent = self.indentation().unwrap());
         self.branch_match
             .push(format!("fun_end{fun_count}", fun_count = self.fun_count));
@@ -278,15 +278,15 @@ addq $8, %rsp       # Deallocate the space on the stack",
         // Ok("*ptr = reg;".to_string())
         todo!()
     }
-    fn prelude(&self, is_core: bool) -> Option<String> {
-        let mut result = ".text
+    fn prelude(&self, _is_core: bool) -> Option<String> {
+        let result = ".text
 .globl main
 main:
 ";
         Some(result.to_string())
     }
 
-    fn post_funs(&self, funs: Vec<i32>) -> Option<String> {
+    fn post_funs(&self, _funs: Vec<i32>) -> Option<String> {
         None
     }
 


### PR DESCRIPTION
Indexing operations are very fast for pointers, but some kinds of data that can be indexed aren't pointer types. For example `['a', 'b', 'c', 'd', 'e'][0]` does not use pointers to do the address calculation, instead its pushed onto the stack and *then* the address calculation can be performed on the data on the stack. This was also performed for arrays that were indexed after a member access (like `a.b[0]`) or dereferenced arrays (like `(*a)[0]`) or a nested index `a[0][0]`.

This PR tries to reference the inner expression and index the pointer by default for any expression, and then will fallback on the stack operation method.

This PR also fixes a bug where `Expr::As(expr, ty)` was not typechecking the inner expression, only confirming that it could be cast to the target type. This prevented the existing optimization from passing the tests before, but it has now been discovered and fixed.