### PR TITLE
WIP: Coallesce LIR declaration types, and add pattern match let bindings.

### DIFF
--- a/examples/frontend/pattern.sg
+++ b/examples/frontend/pattern.sg
@@ -1,0 +1,24 @@
+
+let (x, y) = (5, 6);
+print("Printing tuple members: ", x, " ", y, "\n");
+
+let {a, b} = {a=20, b=30};
+print("Printing struct members: ", a, " ", b, "\n");
+
+let (a, {x, c, b}, d) = (1, {b=2, c=3, x="hello world!"}, 4);
+print("Printing nested struct and tuple members: ",
+    a, " ",
+    b, " ",
+    c, " ",
+    d, " ",
+    x, "\n");
+
+let {a, b, c} = {a=1, b=2, c=3};
+print("Printing struct members: ", a, " ", b, " ", c, "\n");
+
+
+let (a, b, c, d) = (1, 2) + (3, 4);
+print("Printing tuple members: ", a, " ", b, " ", c, " ", d, "\n");
+
+let {d, b, a, c} = {a=1, c=3} + {b=2, d=4};
+print("Printing struct members: ", a, " ", b, " ", c, " ", d, "\n");

--- a/src/frontend/parse.pest
+++ b/src/frontend/parse.pest
@@ -128,7 +128,10 @@ long_stmt = {
     | stmt_match) ~ ";"*
 }
 short_stmt = {
-    (stmt_let_static | stmt_let | stmt_return | stmt_assign | expr) ~ ";"+
+    (stmt_let_static | stmt_let | stmt_let_pat | stmt_return | stmt_assign | expr) ~ ";"+
+}
+stmt_let_pat = {
+    "let" ~ (pattern_term ~ "=" ~ expr ~ ",")* ~ pattern_term ~ "=" ~ expr
 }
 stmt_let = {
     // stmt_let_typed

--- a/src/lir/env.rs
+++ b/src/lir/env.rs
@@ -4,7 +4,7 @@
 //! defined in a given scope. It also stores the variables defined in the scope, and the their offsets
 //! with respect to the frame pointer.
 
-use super::{Compile, ConstExpr, Error, GetSize, Mutability, Procedure, Type};
+use super::{Compile, ConstExpr, Declaration, Error, GetType, GetSize, Mutability, FFIProcedure, PolyProcedure, Procedure, Type};
 use crate::asm::{AssemblyProgram, Globals, Location};
 use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::{
@@ -85,6 +85,103 @@ impl Env {
         }
     }
 
+    /// Add all the declarations to this environment.
+    pub(super) fn add_declaration(&mut self, declaration: &Declaration) -> Result<(), Error> {
+        self.add_compile_time_declaration(declaration)?;
+        self.add_variable_declaration(declaration)?;
+        Ok(())
+    }
+
+    /// Add all the compile-time declarations to this environment. These are declarations
+    /// for types, constants, and procedures that are defined at compile-time. Variables
+    /// are not included because they are defined at runtime.
+    pub(super) fn add_compile_time_declaration(&mut self, declaration: &Declaration) -> Result<(), Error> {
+        match declaration {
+            Declaration::Type(name, ty) => {
+                self.define_type(name, ty.clone());
+            }
+            Declaration::Const(name, e) => {
+                self.define_const(name, e.clone());
+            }
+            Declaration::Proc(name, proc) => {
+                self.define_proc(name, proc.clone());
+            }
+            Declaration::PolyProc(name, proc) => {
+                self.define_poly_proc(name, proc.clone());
+            }
+            Declaration::ExternProc(name, proc) => {
+                self.define_ffi_proc(name, proc.clone());
+            }
+            Declaration::StaticVar(name, mutability, ty, _expr) => {
+                self.define_static_var(name, *mutability, ty.clone())?;
+            }
+            Declaration::Var(_, _, _, _) => {
+                // Variables are not defined at compile-time.
+            }
+            Declaration::VarPat(_, _) => {
+                // Variables are not defined at compile-time.
+            }
+            Declaration::Many(decls) => {
+                for decl in decls {
+                    self.add_compile_time_declaration(decl)?;
+                }
+                for decl in decls {
+                    if let Declaration::Type(name, ty) = decl {
+                        if let Ok(size) = ty.get_size(self) {
+                            self.set_precalculated_size(ty.clone(), size);
+                        } else {
+                            warn!("Failed to memoize type size for {name} = {ty}");
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Add a single variable declaration to this environment. These are declarations
+    /// for variables that are defined at runtime. Types, constants, and procedures
+    /// are not included because they are defined at compile-time.
+    pub(super) fn add_variable_declaration(&mut self, declaration: &Declaration) -> Result<(), Error> {
+        match declaration {
+            Declaration::Type(_, _) => {
+                // Types are not defined at runtime.
+            }
+            Declaration::Const(_, _) => {
+                // Constants are not defined at runtime.
+            }
+            Declaration::Proc(_, _) => {
+                // Procedures are not defined at runtime.
+            }
+            Declaration::PolyProc(_, _) => {
+                // Polymorphic procedures are not defined at runtime.
+            }
+            Declaration::ExternProc(_, _) => {
+                // FFI procedures are not defined at runtime.
+            }
+            Declaration::StaticVar(_, _, _, _) => {
+                // Static variables are not defined at runtime.
+            }
+            Declaration::Var(name, mutability, ty, expr) => {
+                let ty = match ty {
+                    Some(ty) => ty.clone(),
+                    None => expr.get_type(self)?,
+                };
+                self.define_var(name, *mutability, ty)?;
+            }
+            Declaration::VarPat(pat, expr) => {
+                let ty = expr.get_type(self)?;
+                pat.declare_let_bind(expr, &ty, self)?;
+            }
+            Declaration::Many(decls) => {
+                for decl in decls {
+                    self.add_variable_declaration(decl)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Define a static variable with a given name under this environment.
     pub(super) fn define_static_var(
         &mut self,
@@ -102,6 +199,11 @@ impl Env {
         Ok(location)
     }
 
+    /// Get a static variable definition from this environment.
+    /// This contains:
+    /// 1. The mutability of the variable.
+    /// 2. The type of the variable.
+    /// 3. The location of the variable in memory.
     pub(super) fn get_static_var(&self, name: &str) -> Option<&(Mutability, Type, Location)> {
         self.static_vars.get(name)
     }
@@ -175,6 +277,20 @@ impl Env {
         let name = name.to_string();
         trace!("Defining procedure {name} as {proc}");
         Rc::make_mut(&mut self.procs).insert(name, proc);
+    }
+
+    /// Define a polymorphic procedure with a given name under this environment.
+    pub(super) fn define_poly_proc(&mut self, name: impl ToString, proc: PolyProcedure) {
+        let name = name.to_string();
+        trace!("Defining polymorphic procedure {name} as {proc}");
+        Rc::make_mut(&mut self.consts).insert(name, ConstExpr::PolyProc(proc));
+    }
+
+    /// Define an FFI procedure with a given name under this environment.
+    pub(super) fn define_ffi_proc(&mut self, name: impl ToString, proc: FFIProcedure) {
+        let name = name.to_string();
+        trace!("Defining FFI procedure {name} as {proc}");
+        Rc::make_mut(&mut self.consts).insert(name, ConstExpr::FFIProcedure(proc));
     }
 
     /// Get a procedure definition from this environment.
@@ -337,22 +453,22 @@ impl Env {
 impl Display for Env {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         writeln!(f, "Env")?;
-        writeln!(f, "   Types:")?;
-        for (name, ty) in self.types.iter() {
-            writeln!(f, "      {}: {}", name, ty)?;
-        }
-        writeln!(f, "   Constants:")?;
-        for (name, e) in self.consts.iter() {
-            writeln!(f, "      {}: {}", name, e)?;
-        }
-        writeln!(f, "   Procedures:")?;
-        for (name, proc) in self.procs.iter() {
-            writeln!(f, "      {}: {}", name, proc)?;
-        }
-        writeln!(f, "   Globals:")?;
-        for (name, (mutability, ty, location)) in self.static_vars.iter() {
-            writeln!(f, "      {mutability} {name}: {ty} (location {location})")?;
-        }
+        // writeln!(f, "   Types:")?;
+        // for (name, ty) in self.types.iter() {
+        //     writeln!(f, "      {}: {}", name, ty)?;
+        // }
+        // writeln!(f, "   Constants:")?;
+        // for (name, e) in self.consts.iter() {
+        //     writeln!(f, "      {}: {}", name, e)?;
+        // }
+        // writeln!(f, "   Procedures:")?;
+        // for (name, proc) in self.procs.iter() {
+        //     writeln!(f, "      {}: {}", name, proc)?;
+        // }
+        // writeln!(f, "   Globals:")?;
+        // for (name, (mutability, ty, location)) in self.static_vars.iter() {
+        //     writeln!(f, "      {mutability} {name}: {ty} (location {location})")?;
+        // }
         writeln!(f, "   Variables:")?;
         for (name, (mutability, ty, offset)) in self.vars.iter() {
             writeln!(f, "      {mutability} {name}: {ty} (frame-offset {offset})")?;

--- a/src/lir/expr/declaration.rs
+++ b/src/lir/expr/declaration.rs
@@ -1,0 +1,370 @@
+use crate::{lir::{Expr, Env, Compile, Error, GetType, Type, TypeCheck, Mutability, ConstExpr, FFIProcedure, Pattern, GetSize}, asm::{AssemblyProgram, SP, CoreOp, Location}};
+use super::{Procedure, PolyProcedure};
+
+use std::collections::BTreeMap;
+use core::ops::Add;
+use core::fmt::{Display, Formatter, Result as FmtResult};
+use log::debug;
+
+/// A declaration of a variable, function, type, etc.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Declaration {
+    /// A static variable declaration.
+    StaticVar(String, Mutability, Type, ConstExpr),
+    /// A variable declaration.
+    Var(String, Mutability, Option<Type>, Expr),
+    /// A procedure declaration.
+    Proc(String, Procedure),
+    /// A polymorphic procedure declaration.
+    PolyProc(String, PolyProcedure),
+    /// A type declaration.
+    Type(String, Type),
+    /// A constant expression.
+    Const(String, ConstExpr),
+    /// A variable declaration with a pattern.
+    VarPat(Pattern, Expr),
+    /// A foreign function declaration.
+    ExternProc(String, FFIProcedure),
+    /// Many declarations.
+    Many(Vec<Declaration>),
+}
+
+impl Declaration {
+    /// Flatten a multi-declaration into a single-dimensional vector of declarations.
+    pub(crate) fn flatten(self) -> Vec<Self> {
+        match self {
+            Self::Many(decls) => {
+                let mut flattened = Vec::new();
+                for decl in decls {
+                    flattened.extend(decl.flatten());
+                }
+                flattened
+            }
+            decl => vec![decl],
+        }
+    }
+
+    /// Compile a declaration, and return how many cells were allocated for variables.
+    pub(crate) fn compile(&self, body: &Expr, env: &mut Env, output: &mut dyn AssemblyProgram) -> Result<usize, Error> {
+        env.add_compile_time_declaration(self)?;
+        let mut var_size = 0;
+        match self {
+            Declaration::Var(name, _mutability, specifier, expr) => {
+                let current_instruction = output.current_instruction();
+                let message = format!("Initializing '{name}' with expression '{expr}'");
+                // Get the type of the variable using its specifier,
+                // or by deducing the type ourselves.
+                let var_ty = if let Some(specified_ty) = specifier {
+                    specified_ty.clone()
+                } else {
+                    expr.get_type(env)?
+                };
+                var_size = var_ty.get_size(env)?;
+                // Compile the expression to leave the value on the stack.
+                expr.clone().compile_expr(env, output)?;
+
+                // Get the size of the variable we are writing to.
+                env.add_variable_declaration(self)?;
+                output.log_instructions_after(&name, &message, current_instruction);
+            }
+            Declaration::VarPat(pat, expr) => {
+                let expr_ty = expr.get_type(env)?;
+                var_size = expr_ty.get_size(env)?;
+                expr.clone().compile_expr(env, output)?;
+                pat.declare_let_bind(&expr, &expr_ty, env)?;
+            }
+            Declaration::StaticVar(name, _mutability, ty, expr) => {
+                let current_instruction = output.current_instruction();
+                let message = format!("Initializing static variable '{name}' with expression '{expr}'");
+                let var_ty = ty.clone();
+                var_size = var_ty.get_size(env)?;
+                expr.clone().compile_expr(env, output)?;
+                let size = var_ty.get_size(env)?;
+                // Store the value in the variable.
+                output.op(CoreOp::Global {
+                    name: name.clone(),
+                    size,
+                });
+                output.op(CoreOp::Pop(Some(Location::Global(name.clone())), size));
+                output.log_instructions_after(&name, &message, current_instruction);
+            }
+            Declaration::Many(decls) => {
+                for decl in decls {
+                    var_size += decl.compile(body, env, output)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(var_size)
+    }
+
+    pub(crate) fn join(mut self, other: Self) -> Self {
+        match (&mut self, other) {
+            (Self::Many(decls), Self::Many(other_decls)) => {
+                decls.extend(other_decls);
+                self
+            }
+            (Self::Many(decls), other) => {
+                decls.push(other);
+                self
+            }
+            (self_, Self::Many(mut other_decls)) => {
+                other_decls.push(self_.clone());
+                Self::Many(other_decls)
+            }
+            (self_, other) => {
+                Self::Many(vec![self_.clone(), other])
+            }
+        }
+    }
+
+    /// Substitute a type symbol for a type.
+    pub(crate) fn substitute(&mut self, name: &str, ty: &Type) {
+        match self {
+            Self::StaticVar(name, _mutability, expected_ty, expr) => {
+                expr.substitute(name, ty);
+                expected_ty.substitute(name, ty);
+            }
+            Self::Var(name, _mutability, expected_ty, expr) => {
+                expr.substitute(name, ty);
+                if let Some(expected_ty) = expected_ty {
+                    expected_ty.substitute(name, ty);
+                }
+            }
+            Self::Proc(name, proc) => {
+                proc.substitute(name, ty);
+            }
+            Self::PolyProc(name, proc) => {
+                proc.substitute(name, ty);
+            }
+            Self::Type(name, ty) => {
+                ty.substitute(name, ty);
+            }
+            Self::Const(name, expr) => {
+                expr.substitute(name, ty);
+            }
+            Self::VarPat(_pat, expr) => {
+                expr.substitute(name, ty);
+            }
+            Self::ExternProc(name, proc) => {
+                proc.substitute(name, ty);
+            }
+            Self::Many(decls) => {
+                for decl in decls {
+                    decl.substitute(name, ty);
+                }
+            }
+        }
+    }
+}
+
+impl TypeCheck for Declaration {
+    fn type_check(&self, env: &Env) -> Result<(), Error> {
+        match self {
+            Self::Var(_name, _mutability, expected_ty, expr) => {
+                let found_ty = expr.get_type(env)?;
+                if let Some(expected_ty) = expected_ty {
+                    expected_ty.type_check(env)?;
+                    if !found_ty.can_decay_to(expected_ty, env)? {
+                        return Err(Error::MismatchedTypes {
+                            expected: expected_ty.clone(),
+                            found: found_ty.clone(),
+                            expr: Expr::NONE.with(self.clone())
+                        });
+                    }
+                }
+
+                expr.type_check(env)?;
+            }
+            Self::Proc(name, proc) => {
+                let mut new_env = env.clone();
+                new_env.define_proc(name, proc.clone());
+                proc.type_check(&new_env)?;
+            }
+            Self::PolyProc(name, proc) => {
+                let mut new_env = env.clone();
+                new_env.define_poly_proc(name, proc.clone());
+                proc.type_check(&new_env)?;
+            }
+            Self::Type(name, ty) => {
+                let mut new_env = env.clone();
+                new_env.define_type(name, ty.clone());
+                ty.type_check(&new_env)?;
+            }
+            Self::Const(name, expr) => {
+                let mut new_env = env.clone();
+                new_env.define_const(name, expr.clone());
+                expr.type_check(&new_env)?;
+            }
+            Self::StaticVar(name, mutability, expected_ty, expr) => {
+                let mut new_env = env.clone();
+                new_env.define_static_var(name, *mutability, expected_ty.clone())?;
+                let found_ty = expr.get_type(&new_env)?;
+                expected_ty.type_check(&new_env)?;
+                expr.type_check(&new_env)?;
+
+                if !found_ty.can_decay_to(expected_ty, &new_env)? {
+                    return Err(Error::MismatchedTypes {
+                        expected: expected_ty.clone(),
+                        found: found_ty.clone(),
+                        expr: Expr::NONE.with(self.clone())
+                    });
+                }
+            }
+            Self::VarPat(pat, expr) => {
+                let ty = expr.get_type(env)?;
+                let size = ty.get_size(env)?;
+                if !pat.is_exhaustive(&expr, &ty, env)? {
+                    return Err(Error::NonExhaustivePatterns {
+                        patterns: vec![pat.clone()],
+                        expr: Expr::NONE.with(self.clone()),
+                    });
+                }
+                let bindings = pat.get_bindings(&expr, &ty, env)?;
+                let size_of_bindings = bindings.iter().map(|(_name, (_mut, ty))| ty.get_size(env).unwrap_or(0)).sum::<usize>();
+                if size_of_bindings != size {
+                    return Err(Error::InvalidPatternForExpr(Expr::NONE.with(self.clone()), pat.clone()));
+                }
+                
+                pat.type_check(&expr, &Expr::NONE, env)?;
+                expr.type_check(env)?;
+            }
+            Self::ExternProc(_name, proc) => {
+                proc.type_check(env)?;
+            }
+            Self::Many(decls) => {
+                let mut new_env = env.clone();
+                new_env.add_compile_time_declaration(&self.clone())?;
+                for decl in decls {
+                    decl.type_check(&new_env)?;
+                    new_env.add_declaration(decl)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Display for Declaration {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            Self::StaticVar(name, mutability, ty, expr) => {
+                write!(f, "static {mutability} {name}: {ty} = {expr}")?;
+            },
+            Self::Var(name, mutability, ty, expr) => {
+                write!(f, "{} {} = {}", mutability, name, expr)?;
+                if let Some(ty) = ty {
+                    write!(f, ": {}", ty)?;
+                }
+            },
+            Self::Proc(name, proc) => {
+                write!(f, "{}", proc)?;
+                write!(f, " {}", name)?;
+            },
+            Self::PolyProc(name, proc) => {
+                write!(f, "{}", proc)?;
+                write!(f, " {}", name)?;
+            },
+            Self::Type(name, ty) => {
+                write!(f, "type {}", name)?;
+                write!(f, " = {}", ty)?;
+            },
+            Self::Const(name, expr) => {
+                write!(f, "const {}: {}", name, expr)?;
+            },
+            Self::VarPat(pat, expr) => {
+                write!(f, "{} = {}", pat, expr)?;
+            },
+            Self::ExternProc(name, proc) => {
+                write!(f, "extern {}", proc)?;
+                write!(f, " {}", name)?;
+            },
+            Self::Many(decls) => {
+                for decl in decls {
+                    writeln!(f, "{}", decl)?;
+                }
+            },
+        }
+        Ok(())
+    }
+}
+
+impl From<(String, Type)> for Declaration {
+    fn from((name, ty): (String, Type)) -> Self {
+        Self::Type(name, ty)
+    }
+}
+
+impl From<(String, Expr)> for Declaration {
+    fn from((name, expr): (String, Expr)) -> Self {
+        Self::Var(name, Mutability::Immutable, None, expr)
+    }
+}
+
+impl From<(String, Mutability, Expr)> for Declaration {
+    fn from((name, mutability, expr): (String, Mutability, Expr)) -> Self {
+        Self::Var(name, mutability, None, expr)
+    }
+}
+
+impl From<(String, Mutability, Type, Expr)> for Declaration {
+    fn from((name, mutability, ty, expr): (String, Mutability, Type, Expr)) -> Self {
+        Self::Var(name, mutability, Some(ty), expr)
+    }
+}
+
+impl From<(String, Mutability, Option<Type>, Expr)> for Declaration {
+    fn from((name, mutability, ty, expr): (String, Mutability, Option<Type>, Expr)) -> Self {
+        Self::Var(name, mutability, ty, expr)
+    }
+}
+
+impl From<(String, Procedure)> for Declaration {
+    fn from((name, proc): (String, Procedure)) -> Self {
+        Self::Proc(name, proc)
+    }
+}
+
+impl From<(String, PolyProcedure)> for Declaration {
+    fn from((name, proc): (String, PolyProcedure)) -> Self {
+        Self::PolyProc(name, proc)
+    }
+}
+
+impl From<(String, ConstExpr)> for Declaration {
+    fn from((name, expr): (String, ConstExpr)) -> Self {
+        Self::Const(name, expr)
+    }
+}
+
+impl From<(Pattern, Expr)> for Declaration {
+    fn from((pat, expr): (Pattern, Expr)) -> Self {
+        Self::VarPat(pat, expr)
+    }
+}
+
+impl From<(String, FFIProcedure)> for Declaration {
+    fn from((name, proc): (String, FFIProcedure)) -> Self {
+        Self::ExternProc(name, proc)
+    }
+}
+
+impl<K, V> From<BTreeMap<K, V>> for Declaration where (K, V): Into<Declaration> {
+    fn from(bt: BTreeMap<K, V>) -> Self {
+        Self::Many(bt.into_iter().map(|(k, v)| (k, v).into()).collect())
+    }
+}
+
+impl<T> From<Vec<T>> for Declaration where T: Into<Declaration> {
+    fn from(decls: Vec<T>) -> Self {
+        Self::Many(decls.into_iter().map(|decl| decl.into()).collect())
+    }
+}
+
+impl<T> Add<T> for Declaration where T: Into<Declaration> {
+    type Output = Self;
+
+    fn add(self, other: T) -> Self::Output {
+        self.join(other.into())
+    }
+}

--- a/src/lir/expr/mod.rs
+++ b/src/lir/expr/mod.rs
@@ -6,9 +6,11 @@ mod expression;
 mod ops;
 mod pattern;
 mod procedure;
+mod declaration;
 
 pub use const_expr::*;
 pub use expression::*;
 pub use ops::*;
 pub use pattern::*;
 pub use procedure::*;
+pub use declaration::*;

--- a/src/lir/expr/pattern.rs
+++ b/src/lir/expr/pattern.rs
@@ -83,6 +83,11 @@ impl Pattern {
         branch.get_type(&new_env)
     }
 
+    /// Is this pattern exhaustive?
+    pub fn is_exhaustive(&self, expr: &Expr, ty: &Type, env: &Env) -> Result<bool, Error> {
+        Self::are_patterns_exhaustive(&expr, &[self.clone()], &ty, &env)
+    }
+
     /// This associated function returns whether or not a set of patterns is exhaustive,
     /// that is, whether or not it matches all possible values of a given type.
     /// This is used to check if a `match` expression is exhaustive.
@@ -357,6 +362,33 @@ impl Pattern {
                 Ok(found.iter().all(|b| *b))
             }
 
+            // Is the inner pattern exhaustive?
+            Type::Pointer(_mutability, elem_ty) => {
+                // If the type is a pointer, the patterns are exhaustive if the inner pattern is exhaustive.
+                for pattern in patterns {
+                    match pattern {
+                        Pattern::Pointer(inner) => {
+                            // If there's a pattern which matches a pointer, check if the inner pattern is exhaustive.
+                            if Self::are_patterns_exhaustive(expr, &[*inner.clone()], elem_ty, env)? {
+                                // If it is exhaustive, return `true`.
+                                return Ok(true);
+                            }
+                        }
+                        Pattern::Wildcard | Pattern::Symbol(_, _) => return Ok(true),
+                        Pattern::Alt(branches) => {
+                            // If there's an alternate pattern, check if it's exhaustive.
+                            if Self::are_patterns_exhaustive(expr, branches, matching_expr_ty, env)?
+                            {
+                                // If it is exhaustive, return `true`.
+                                return Ok(true);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(false)
+            }
+
             // For any other type, only a default pattern is exhaustive.
             _ => {
                 for pattern in patterns {
@@ -423,7 +455,8 @@ impl Pattern {
                         vec![(self.clone(), branch.clone())],
                     ),
                 })
-            } // Err(e) => return Err(Error::InvalidPatternForExpr(matching_expr.clone(), self.clone())),
+            }
+            // Err(e) => return Err(Error::InvalidPatternForExpr(matching_expr.clone(), self.clone())),
         }
         // Generate an expression with the bindings defined for the branch.
         let result_expr = self
@@ -494,14 +527,6 @@ impl Pattern {
         // Get the type of the expression being matched
         let match_type = expr.get_type(env)?.simplify_until_concrete(env)?;
         // Define the variable in the new environment.
-        // for _ in 0..Type::SIMPLIFY_RECURSION_LIMIT {
-        //     match match_type {
-        //         Type::Let(_, _, _) | Type::Symbol(_) => {
-        //             match_type = match_type.simplify(env)?;
-        //         }
-        //         _ => break,
-        //     }
-        // }
         new_env.define_var(var_name.clone(), Mutability::Immutable, match_type.clone())?;
         // Generate the expression which evaluates the `match` expression.
         let match_expr = Pattern::match_pattern_helper(&Expr::var(&var_name), branches, &new_env)?;
@@ -551,12 +576,21 @@ impl Pattern {
     /// For example `(a, b)` binds the variables `a` and `b` to the first and second
     /// elements of the tuple respectively. This function would return a map with
     /// the keys `a` and `b` and the values being their types.
-    pub fn get_bindings(
+    pub fn get_bindings(&self, expr: &Expr, ty: &Type, env: &Env) -> Result<HashMap<String, (Mutability, Type)>, Error> {
+        Ok(self.get_bindings_with_offset(expr, ty, env, 0)?
+            .into_iter()
+            .map(|(k, (m, t, _))| (k, (m, t)))
+            .collect())
+    }
+
+    /// Get the map of new variables, their types which are bound by this pattern, and their offsets in the expression.
+    fn get_bindings_with_offset(
         &self,
         expr: &Expr,
         ty: &Type,
         env: &Env,
-    ) -> Result<HashMap<String, (Mutability, Type)>, Error> {
+        mut origin: usize,
+    ) -> Result<HashMap<String, (Mutability, Type, usize)>, Error> {
         let ty = &ty.simplify_until_concrete(env)?;
         Ok(match (self, ty) {
             // If the pattern is a tuple, and the type is a tuple, then
@@ -569,13 +603,15 @@ impl Pattern {
                     // Get the bindings for the pattern and add them to the result.
                     result.extend(
                         pattern
-                            .get_bindings(
+                            .get_bindings_with_offset(
                                 &expr.clone().field(ConstExpr::Int(i as i64)),
                                 item_type,
                                 env,
+                                origin,
                             )?
                             .into_iter(),
-                    )
+                    );
+                    origin += item_type.get_size(env)?;
                 }
                 // Return the result.
                 result
@@ -590,13 +626,14 @@ impl Pattern {
                 }
                 // If no error was thrown, the variant is an option which can be matched.
                 // Now, check if the tag matches the variant.
-                pattern.get_bindings(
+                pattern.get_bindings_with_offset(
                     &expr
                         .clone()
                         .unop(super::ops::Data)
                         .field(ConstExpr::Symbol(name.clone())),
                     &variants[name],
                     env,
+                    origin,
                 )?
             }
 
@@ -604,21 +641,26 @@ impl Pattern {
             // get the bindings for each field of the struct.
             (Self::Struct(patterns), Type::Struct(item_types)) => {
                 let mut result = HashMap::new();
+
+                let save = origin;
                 // Iterate over the field names and patterns of the struct.
                 for (name, pattern) in patterns.iter() {
+                    let symbol = ConstExpr::Symbol(name.clone());
                     // If the struct has a field with the given name, then
                     // get the bindings for the pattern and add them to the result.
                     if let Some(item_type) = item_types.get(name) {
                         // Get the bindings for the pattern and add them to the result.
+                        origin = save + ty.get_member_offset(&symbol, expr, env)?.1;
                         result.extend(
                             pattern
-                                .get_bindings(
-                                    &expr.clone().field(ConstExpr::Symbol(name.clone())),
+                                .get_bindings_with_offset(
+                                    &expr.clone().field(symbol),
                                     item_type,
                                     env,
+                                    origin,
                                 )?
                                 .into_iter(),
-                        )
+                        );
                     } else {
                         // If the struct does not have a field with the given name, then
                         // return an error.
@@ -632,7 +674,7 @@ impl Pattern {
             (Self::Symbol(mutability, name), ty) => {
                 let mut result = HashMap::new();
                 // Add the symbol to the result with the type of the expression.
-                result.insert(name.clone(), (*mutability, ty.clone()));
+                result.insert(name.clone(), (*mutability, ty.clone(), origin));
                 result
             }
 
@@ -643,7 +685,7 @@ impl Pattern {
             | (Self::ConstExpr(_), _) => HashMap::new(),
 
             (Self::Pointer(pattern), Type::Pointer(_, item_type)) => {
-                pattern.get_bindings(&expr.clone().deref(), item_type, env)?
+                pattern.get_bindings_with_offset(&expr.clone().deref(), item_type, env, origin)?
             }
 
             // If the pattern is an alternative, then get the bindings for each pattern
@@ -652,14 +694,28 @@ impl Pattern {
                 // Iterate over the patterns.
                 for (i, pattern) in patterns.iter().enumerate() {
                     // Get the bindings for the pattern and add them to the result.
-                    let bindings = pattern.get_bindings(expr, ty, env)?;
+                    let bindings = pattern.get_bindings_with_offset(expr, ty, env, origin)?;
                     // If this is the first pattern, then set the result to the bindings.
                     if i == 0 {
                         result = bindings;
-                    } else if result != bindings {
+                    } else {
+                        // Compare the mutability and types of the bindings for this pattern
+                        for (var, (mutability, ty, _)) in bindings {
+                            // If the variable is not in the result, then add it.
+                            if !result.contains_key(&var) {
+                                return Err(Error::InvalidPatternForExpr(expr.clone(), self.clone()));
+                            } else {
+                                // If the variable is in the result, then check if the mutability and type match.
+                                let (prev_mutability, prev_ty, _) = &result[&var];
+                                if *prev_mutability != mutability || *prev_ty != ty {
+                                    // If the bindings for this pattern are different to the previous patterns,
+                                    // then return an error.
+                                    return Err(Error::InvalidPatternForExpr(expr.clone(), self.clone()));
+                                }
+                            }
+                        }
                         // If the bindings for this pattern are different to the previous patterns,
                         // then return an error.
-                        return Err(Error::InvalidPatternForExpr(expr.clone(), self.clone()));
                     }
                 }
                 // Return the result.
@@ -825,6 +881,21 @@ impl Pattern {
 
             _ => return Err(Error::InvalidPatternForExpr(expr.clone(), self.clone())),
         })
+    }
+
+    /// Let-bind the pattern to the given expression. This will define all the bindings
+    /// in the environment, and then assign the bound expression to all the pattern bindings.
+    pub fn declare_let_bind(&self, expr: &Expr, ty: &Type, env: &mut Env) -> Result<(), Error> {
+        let ty = &ty.simplify_until_concrete(env)?;
+        let bindings = self.get_bindings_with_offset(expr, ty, env, 0)?;
+        // Sort the bindings by their offset.
+        let mut bindings: Vec<_> = bindings.into_iter().collect();
+        bindings.sort_by_key(|(_, (_, _, offset))| *offset);
+        // Define all the bindings in the environment.
+        for (name, (mutability, ty, _)) in &bindings {
+            env.define_var(name, *mutability, ty.clone())?;
+        }
+        Ok(())
     }
 
     /// Bind the pattern to the given expression.

--- a/src/lir/types/check.rs
+++ b/src/lir/types/check.rs
@@ -183,6 +183,17 @@ impl TypeCheck for Expr {
                 expr.type_check(env).map_err(|e| e.with_loc(loc))
             }
 
+            Self::Declare(declaration, body) => {
+                // Create a new environment with the declarations defined.
+                let mut new_env = env.clone();
+                // Check the declaration.
+                declaration.type_check(&new_env)?;
+                // Add the declarations to the environment.
+                new_env.add_declaration(&declaration)?;
+                // Check the body with the declarations defined.
+                body.type_check(&new_env)
+            }
+
             Self::UnaryOp(unop, expr) => {
                 // Check if the unary operator is sound with
                 // the given expression.

--- a/src/lir/types/inference.rs
+++ b/src/lir/types/inference.rs
@@ -45,6 +45,15 @@ impl GetType for Expr {
                 expr.get_type_checked(env, i).map_err(|e| e.with_loc(loc))?
             }
 
+            Self::Declare(declaration, body) => {
+                // Create a new environment with the declarations.
+                let mut new_env = env.clone();
+                // Add the declarations to the environment.
+                new_env.add_declaration(&declaration)?;
+                // Get the type of the body in the new environment.
+                body.get_type_checked(&new_env, i)?
+            }
+
             Self::LetStaticVar(name, mutability, ty, _const_val, ret) => {
                 // Create a new environment with the static variable.
                 let mut new_env = env.clone();
@@ -452,6 +461,11 @@ impl GetType for Expr {
         match self {
             Self::AnnotatedWithSource { expr, .. } => {
                 expr.substitute(name, ty);
+            }
+
+            Self::Declare(declaration, body) => {
+                declaration.substitute(name, ty);
+                body.substitute(name, ty);
             }
 
             Self::ConstExpr(cexpr) => cexpr.substitute(name, ty),


### PR DESCRIPTION
Take `Expr::LetTypes`, `Expr::LetConsts`, `Expr::LetVars`, `Expr::LetStaticVars`, etc. and encapsulate them all into `Expr::Declare` which takes a declaration. `Declaration`s can be composed of multiple sub-declarations.